### PR TITLE
Big input workaround example

### DIFF
--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -119,7 +119,7 @@ def call_put_obs(stub, obs_count, summary_size):
                 continue
 
             # give up
-            print(f"unexpected error (code: {err.code()}; details: {err.details()}")
+            print(f"unexpected error (code: {err.code()}; details: {err.details()})")
             break
 
     # NOTE: at this point, the overall set of observations has been completely

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -104,8 +104,7 @@ def call_put_obs(stub, obs_count, summary_size):
         except grpc.RpcError as err:
             if err.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
                 if len(obs0) == 1:  # give up, since even a single observation
-                    # (that may not be split further!) is too big for a
-                    # single message
+                    # (that may not be split further!) is too big for a single message
                     print("error: even a single obs is too big for a single message")
                     break
 
@@ -120,9 +119,7 @@ def call_put_obs(stub, obs_count, summary_size):
                 continue
 
             # give up
-            print("unexpected error:")
-            print(f"code: {err.code()}")
-            print(f"details: {err.details()}")
+            print(f"unexpected error (code: {err.code()}; details: {err.details()}")
             break
 
     # NOTE: at this point, the overall set of observations has been completely

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -46,8 +46,7 @@ def create_observations(obs_count, summary_size):
         # more attributes ...
     )
 
-    pubtime = dtime2tstamp(
-        datetime(2023, 1, 1, 0, 0, 10, 0, tzinfo=timezone.utc))
+    pubtime = dtime2tstamp(datetime(2023, 1, 1, 0, 0, 10, 0, tzinfo=timezone.utc))
 
     obs = []
 
@@ -112,9 +111,7 @@ def call_put_obs(stub, obs_count, summary_size):
                 if len(obs0) == 1:  # give up, since even a single observation
                     # (that may not be split further!) is too big for a
                     # single message
-                    print(
-                        "error: even a single obs is too big for a single " +
-                        "message")
+                    print("error: even a single obs is too big for a single message")
                     break
 
                 # split obs0 into two subsets, push both on stack,
@@ -140,17 +137,23 @@ def call_put_obs(stub, obs_count, summary_size):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-n", dest="obs_count", default=10000, type=int, metavar="<obs count>",
-        help="total number of observations to insert in the data store " +
-        "(effectively defines an upper bound of the number of calls to " +
-        "PutObservations)")
+        "-n",
+        dest="obs_count",
+        default=10000,
+        type=int,
+        metavar="<obs count>",
+        help="total number of observations to insert in the data store "
+        + "(effectively defines an upper bound of the number of calls to "
+        + "PutObservations)")
     parser.add_argument(
-        "-s", dest="summary_size", default=1000, type=int,
-        metavar="<summary size>", help="size of summary attribute " +
-        "(controls the total size of a single message)")
+        "-s",
+        dest="summary_size",
+        default=1000,
+        type=int,
+        metavar="<summary size>",
+        help="size of summary attribute (controls the total size of a single message)")
     parse_res = parser.parse_args(sys.argv[1:])
     return parse_res.obs_count, parse_res.summary_size
 
@@ -158,8 +161,7 @@ def parse_args():
 if __name__ == "__main__":
 
     with grpc.insecure_channel(
-        f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") \
-            as channel:
+        f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") as channel:
         stub = dstore_grpc.DatastoreStub(channel)
 
         obs_count, summary_size = parse_args()
@@ -167,9 +169,9 @@ if __name__ == "__main__":
         tot_obs, tot_ins, tot_calls = \
             call_put_obs(stub, obs_count, summary_size)
 
-        ps = f'{(tot_ins / tot_obs) * 100:.2f}' if tot_obs > 0 else '0.0'
+        ps = f"{(tot_ins / tot_obs) * 100:.2f}" if tot_obs > 0 else "0.0"
 
         print(
-            f"total observations: {tot_obs}; successfully inserted: " +
-            f"{tot_ins} ({ps}%); " +
-            f"calls to PutObservations: {tot_calls}")
+            f"total observations: {tot_obs}; successfully inserted: "
+            + f"{tot_ins} ({ps}%); "
+            + f"calls to PutObservations: {tot_calls}")

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -1,4 +1,9 @@
-"""Client that demonstrates how to work around gRPC message size limit."""
+"""This client demonstrates how to work around gRPC message size limit by
+   calling PutObservations multiple times.
+   The overall set of observations is gradually split into smaller and
+   smaller parts until each one is successfully accommodated in a single
+   request message to PutObservations.
+"""
 
 # tested with Python 3.11
 #

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -14,7 +14,9 @@
 #       --python_out=../examples/big_input_workaround \
 #       --grpc_python_out=../examples/big_input_workaround
 
-import os, sys, argparse
+import os
+import sys
+import argparse
 from datetime import datetime, timezone
 from collections import deque
 
@@ -110,7 +112,7 @@ def call_put_obs(stub, obs_count, summary_size):
                     # (that may not be split further!) is too big for a
                     # single message
                     print(
-                        'error: even a single obs is too big for a single '+
+                        'error: even a single obs is too big for a single ' +
                         'message')
                     break
 
@@ -124,11 +126,11 @@ def call_put_obs(stub, obs_count, summary_size):
                     stack.append(obs2)
                 continue
 
-            else: # give up
-                print('unexpected error:')
-                print(f'code: {err.code()}')
-                print(f'details: {err.details()}')
-                break
+            # give up
+            print('unexpected error:')
+            print(f'code: {err.code()}')
+            print(f'details: {err.details()}')
+            break
 
     # NOTE: at this point, the overall set of observations has been completely
     # inserted in the store only if no errors occurred in the above loop
@@ -141,12 +143,12 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '-n', dest='obs_count', default=10000, type=int, metavar='<obs count>',
-        help='total number of observations to insert in the data store '+
-        '(effectively defines an upper bound of the number of calls to '+
+        help='total number of observations to insert in the data store ' +
+        '(effectively defines an upper bound of the number of calls to ' +
         'PutObservations)')
     parser.add_argument(
         '-s', dest='summary_size', default=1000, type=int,
-        metavar='<summary size>', help='size of summary attribute '+
+        metavar='<summary size>', help='size of summary attribute ' +
         '(controls the total size of a single message)')
     parse_res = parser.parse_args(sys.argv[1:])
     return parse_res.obs_count, parse_res.summary_size
@@ -167,6 +169,6 @@ if __name__ == "__main__":
         ps = f'{(tot_ins / tot_obs) * 100:.2f}' if tot_obs > 0 else '0.0'
 
         print(
-            f'total observations: {tot_obs}; successfully inserted: '+
-            f'{tot_ins} ({ps}%); '+
+            f'total observations: {tot_obs}; successfully inserted: ' +
+            f'{tot_ins} ({ps}%); ' +
             f'calls to PutObservations(): {tot_calls}')

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -146,32 +146,33 @@ def parse_args():
         metavar="<obs count>",
         help="total number of observations to insert in the data store "
         + "(effectively defines an upper bound of the number of calls to "
-        + "PutObservations)")
+        + "PutObservations)",
+    )
     parser.add_argument(
         "-s",
         dest="summary_size",
         default=1000,
         type=int,
         metavar="<summary size>",
-        help="size of summary attribute (controls the total size of a single message)")
+        help="size of summary attribute (controls the total size of a single message)",
+    )
     parse_res = parser.parse_args(sys.argv[1:])
     return parse_res.obs_count, parse_res.summary_size
 
 
 if __name__ == "__main__":
 
-    with grpc.insecure_channel(
-        f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") as channel:
+    with grpc.insecure_channel(f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") as channel:
         stub = dstore_grpc.DatastoreStub(channel)
 
         obs_count, summary_size = parse_args()
 
-        tot_obs, tot_ins, tot_calls = \
-            call_put_obs(stub, obs_count, summary_size)
+        tot_obs, tot_ins, tot_calls = call_put_obs(stub, obs_count, summary_size)
 
         ps = f"{(tot_ins / tot_obs) * 100:.2f}" if tot_obs > 0 else "0.0"
 
         print(
             f"total observations: {tot_obs}; successfully inserted: "
             + f"{tot_ins} ({ps}%); "
-            + f"calls to PutObservations: {tot_calls}")
+            + f"calls to PutObservations: {tot_calls}"
+        )

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -3,17 +3,16 @@
    The overall set of observations is gradually split into smaller and
    smaller parts until each one is successfully accommodated in a single
    request message to PutObservations.
+
+   Tested with Python 3.11
+
+   If necessary, generate protobuf code by running the following command from
+   the directory that contains the 'protobuf' subdirectory:
+
+     python -m grpc_tools.protoc --proto_path=protobuf datastore.proto \
+         --python_out=../examples/big_input_workaround \
+         --grpc_python_out=../examples/big_input_workaround
 """
-
-# tested with Python 3.11
-#
-# If necessary, generate protobuf code by running the following command from
-# the directory that contains the 'protobuf' subdirectory:
-#
-#   python -m grpc_tools.protoc --proto_path=protobuf datastore.proto \
-#       --python_out=../examples/big_input_workaround \
-#       --grpc_python_out=../examples/big_input_workaround
-
 import argparse
 import os
 import sys
@@ -35,7 +34,6 @@ def dtime2tstamp(dtime):
 
 # create_observations creates a set of observations.
 def create_observations(obs_count, summary_size):
-
     # create time series metadata common to all observations
     ts_mdata = dstore.TSMetadata(
         version="dummy_version",
@@ -83,7 +81,6 @@ def create_observations(obs_count, summary_size):
 #   - number of observations successfully inserted,
 #   - total calls to PutObservations.
 def call_put_obs(stub, obs_count, summary_size):
-
     # create overall set of observations to be inserted in the store
     obs = create_observations(obs_count, summary_size)
 
@@ -96,7 +93,6 @@ def call_put_obs(stub, obs_count, summary_size):
     tot_calls = 0  # total calls to PutObservations
 
     while len(stack) > 0:  # while more (sub)sets remain
-
         # try to insert next (sub)set in the store
         obs0 = stack.pop()
         request = dstore.PutObsRequest(observations=obs0)
@@ -107,7 +103,6 @@ def call_put_obs(stub, obs_count, summary_size):
             tot_calls += 1
         except grpc.RpcError as err:
             if err.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
-
                 if len(obs0) == 1:  # give up, since even a single observation
                     # (that may not be split further!) is too big for a
                     # single message
@@ -161,7 +156,6 @@ def parse_args():
 
 
 if __name__ == "__main__":
-
     with grpc.insecure_channel(f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") as channel:
         stub = dstore_grpc.DatastoreStub(channel)
 

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -1,0 +1,167 @@
+"""Client that demonstrates how to work around gRPC message size limit."""
+
+# tested with Python 3.11
+#
+# If necessary, generate protobuf code by running the following command from
+# the directory that contains the 'protobuf' subdirectory:
+#
+#   python -m grpc_tools.protoc --proto_path=protobuf datastore.proto \
+#       --python_out=../examples/big_input_workaround \
+#       --grpc_python_out=../examples/big_input_workaround
+
+import os, sys, argparse
+from datetime import datetime, timezone
+from collections import deque
+
+import grpc
+from google.protobuf.timestamp_pb2 import Timestamp
+import datastore_pb2 as dstore
+import datastore_pb2_grpc as dstore_grpc
+
+
+def dtime2tstamp(dtime):
+    tstamp = Timestamp()
+    tstamp.FromDatetime(dtime)
+    return tstamp
+
+
+# create_observations creates a set of observations.
+def create_observations(obs_count, summary_size):
+
+    # create time series metadata common to all observations
+    ts_mdata = dstore.TSMetadata(
+        version='dummy_version',
+        type='dummy_type',
+        summary=('x' * summary_size),
+        standard_name='air_temperature',
+        unit='celsius',
+        # more attributes ...
+    )
+
+    pubtime = dtime2tstamp(
+        datetime(2023, 1, 1, 0, 0, 10, 0, tzinfo=timezone.utc))
+
+    obs = []
+
+    # create a set of observations where only the obs time varies
+    for i in range(obs_count):
+        obs_mdata = dstore.ObsMetadata(
+            id='dummy_id',
+            geo_point=dstore.Point(
+                lat=59.91,
+                lon=10.75,
+            ),
+            pubtime=pubtime,
+            data_id='dummy_data_id',
+            obstime_instant=Timestamp(seconds=i),
+            value='12.7',
+            # more attributes ...
+        )
+
+        obs.append(
+            dstore.Metadata1(
+                ts_mdata=ts_mdata,
+                obs_mdata=obs_mdata,
+            )
+        )
+
+    return obs
+
+
+# call_put_obs demonstrates how to robustly insert observations in the store
+# when the set of observations may cause a single request to become too big
+# for the gRPC protocol.
+# Returns three ints:
+#   - total number of observations to be inserted,
+#   - number of observations successfully inserted,
+#   - total calls to PutObservations.
+def call_put_obs(stub, obs_count, summary_size):
+
+    # create overall set of observations to be inserted in the store
+    obs = create_observations(obs_count, summary_size)
+
+    stack = deque()
+
+    if len(obs) > 0:
+        stack.append(obs)  # push overall set on stack
+
+    tot_inserted = 0  # total observations succesfully inserted
+    tot_calls = 0  # total calls to PutObservations
+
+    while len(stack) > 0:  # while more (sub)sets remain
+
+        # try to insert next (sub)set in the store
+        obs0 = stack.pop()
+        request = dstore.PutObsRequest(observations=obs0)
+
+        try:
+            stub.PutObservations(request)
+            tot_inserted += len(obs0)
+            tot_calls += 1
+        except grpc.RpcError as err:
+            if err.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
+
+                if len(obs0) == 1:  # give up, since even a single observation
+                    # (that may not be split further!) is too big for a
+                    # single message
+                    print(
+                        'error: even a single obs is too big for a single '+
+                        'message')
+                    break
+
+                # split obs0 into two subsets, push both on stack,
+                # and try again
+                m = len(obs0) // 2
+                obs1, obs2 = obs0[:m], obs0[m:]
+                if len(obs1) > 0:
+                    stack.append(obs1)
+                if len(obs2) > 0:
+                    stack.append(obs2)
+                continue
+
+            else: # give up
+                print('unexpected error:')
+                print(f'code: {err.code()}')
+                print(f'details: {err.details()}')
+                break
+
+    # NOTE: at this point, the overall set of observations has been completely
+    # inserted in the store only if no errors occurred in the above loop
+
+    return len(obs), tot_inserted, tot_calls
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-n', dest='obs_count', default=10000, type=int, metavar='<obs count>',
+        help='total number of observations to insert in the data store '+
+        '(effectively defines an upper bound of the number of calls to '+
+        'PutObservations)')
+    parser.add_argument(
+        '-s', dest='summary_size', default=1000, type=int,
+        metavar='<summary size>', help='size of summary attribute '+
+        '(controls the total size of a single message)')
+    parse_res = parser.parse_args(sys.argv[1:])
+    return parse_res.obs_count, parse_res.summary_size
+
+
+if __name__ == "__main__":
+
+    with grpc.insecure_channel(
+        f"{os.getenv('DSHOST', 'localhost')}:{os.getenv('DSPORT', '50050')}") \
+            as channel:
+        stub = dstore_grpc.DatastoreStub(channel)
+
+        obs_count, summary_size = parse_args()
+
+        tot_obs, tot_ins, tot_calls = \
+            call_put_obs(stub, obs_count, summary_size)
+
+        ps = f'{(tot_ins / tot_obs) * 100:.2f}' if tot_obs > 0 else '0.0'
+
+        print(
+            f'total observations: {tot_obs}; successfully inserted: '+
+            f'{tot_ins} ({ps}%); '+
+            f'calls to PutObservations(): {tot_calls}')

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -38,11 +38,11 @@ def create_observations(obs_count, summary_size):
 
     # create time series metadata common to all observations
     ts_mdata = dstore.TSMetadata(
-        version='dummy_version',
-        type='dummy_type',
-        summary=('x' * summary_size),
-        standard_name='air_temperature',
-        unit='celsius',
+        version="dummy_version",
+        type="dummy_type",
+        summary=("x" * summary_size),
+        standard_name="air_temperature",
+        unit="celsius",
         # more attributes ...
     )
 
@@ -54,15 +54,15 @@ def create_observations(obs_count, summary_size):
     # create a set of observations where only the obs time varies
     for i in range(obs_count):
         obs_mdata = dstore.ObsMetadata(
-            id='dummy_id',
+            id="dummy_id",
             geo_point=dstore.Point(
                 lat=59.91,
                 lon=10.75,
             ),
             pubtime=pubtime,
-            data_id='dummy_data_id',
+            data_id="dummy_data_id",
             obstime_instant=Timestamp(seconds=i),
-            value='12.7',
+            value="12.7",
             # more attributes ...
         )
 
@@ -113,8 +113,8 @@ def call_put_obs(stub, obs_count, summary_size):
                     # (that may not be split further!) is too big for a
                     # single message
                     print(
-                        'error: even a single obs is too big for a single ' +
-                        'message')
+                        "error: even a single obs is too big for a single " +
+                        "message")
                     break
 
                 # split obs0 into two subsets, push both on stack,
@@ -128,9 +128,9 @@ def call_put_obs(stub, obs_count, summary_size):
                 continue
 
             # give up
-            print('unexpected error:')
-            print(f'code: {err.code()}')
-            print(f'details: {err.details()}')
+            print("unexpected error:")
+            print(f"code: {err.code()}")
+            print(f"details: {err.details()}")
             break
 
     # NOTE: at this point, the overall set of observations has been completely
@@ -143,14 +143,14 @@ def parse_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '-n', dest='obs_count', default=10000, type=int, metavar='<obs count>',
-        help='total number of observations to insert in the data store ' +
-        '(effectively defines an upper bound of the number of calls to ' +
-        'PutObservations)')
+        "-n", dest="obs_count", default=10000, type=int, metavar="<obs count>",
+        help="total number of observations to insert in the data store " +
+        "(effectively defines an upper bound of the number of calls to " +
+        "PutObservations)")
     parser.add_argument(
-        '-s', dest='summary_size', default=1000, type=int,
-        metavar='<summary size>', help='size of summary attribute ' +
-        '(controls the total size of a single message)')
+        "-s", dest="summary_size", default=1000, type=int,
+        metavar="<summary size>", help="size of summary attribute " +
+        "(controls the total size of a single message)")
     parse_res = parser.parse_args(sys.argv[1:])
     return parse_res.obs_count, parse_res.summary_size
 
@@ -170,6 +170,6 @@ if __name__ == "__main__":
         ps = f'{(tot_ins / tot_obs) * 100:.2f}' if tot_obs > 0 else '0.0'
 
         print(
-            f'total observations: {tot_obs}; successfully inserted: ' +
-            f'{tot_ins} ({ps}%); ' +
-            f'calls to PutObservations(): {tot_calls}')
+            f"total observations: {tot_obs}; successfully inserted: " +
+            f"{tot_ins} ({ps}%); " +
+            f"calls to PutObservations: {tot_calls}")

--- a/examples/big_input_workaround/client.py
+++ b/examples/big_input_workaround/client.py
@@ -14,16 +14,17 @@
 #       --python_out=../examples/big_input_workaround \
 #       --grpc_python_out=../examples/big_input_workaround
 
+import argparse
 import os
 import sys
-import argparse
-from datetime import datetime, timezone
 from collections import deque
+from datetime import datetime
+from datetime import timezone
 
-import grpc
-from google.protobuf.timestamp_pb2 import Timestamp
 import datastore_pb2 as dstore
 import datastore_pb2_grpc as dstore_grpc
+import grpc
+from google.protobuf.timestamp_pb2 import Timestamp
 
 
 def dtime2tstamp(dtime):


### PR DESCRIPTION
Client to demonstrate how to work around gRPC message size limit by calling `PutObservations` multiple times.
The overall set of observations is gradually split into smaller and smaller parts until each one is successfully accommodated in a single request message to `PutObservations`.
